### PR TITLE
Use paths from /etc/path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ const profileOrder = [
 ];
 
 const getPathToProfile = (shell) => {
-	let currentProfileOrder = profileOrder.map(p => p.replace("bash", shell)) //in case the default shell is not bash
+	let currentProfileOrder = profileOrder.map(p => p.replace("bash", shell)) // in case the default shell is not bash
 		.map(p => path.join(process.env.HOME, p));
 
 	for (let profileName of currentProfileOrder) {
@@ -26,18 +26,43 @@ const getPathToProfile = (shell) => {
 	}
 };
 
+const addEtcPathToPath = (environmentVariables) => {
+	const pathToEtcPath = "/etc/path";
+
+	if (fs.existsSync(pathToEtcPath)) {
+		const additionsToPath = fs.readFileSync(pathToEtcPath, "utf8")
+			.split('\n')
+			.map(row => row.trim())
+			.join(":");
+
+		if (additionsToPath) {
+			if (environmentVariables.PATH) {
+				environmentVariables.PATH += `:${additionsToPath}`;
+			} else {
+				environmentVariables.PATH = additionsToPath;
+			}
+		}
+	}
+
+	return environmentVariables;
+};
+
+/**
+ * Gets all environment variables that the user has in the default terminal.
+ * @returns {object} Dictionary with key-value pairs of all environment variables.
+ */
 const getEnvironmentVariables = () => {
 	if (processWrapper.getProcessPlatform() === "win32") {
 		return process.env;
 	}
 
 	const shell = process.env && process.env.SHELL && path.basename(process.env.SHELL) || "bash",
-		pathToShell = process.env && process.env.SHELL  || "/bin/bash";
+		pathToShell = process.env && process.env.SHELL || "/bin/bash";
 
 	const profileName = getPathToProfile(shell);
 
 	if (!profileName) {
-		return process.env;
+		return addEtcPathToPath(process.env);
 	}
 
 	try {
@@ -47,25 +72,29 @@ const getEnvironmentVariables = () => {
 			let environmentVariables = {};
 
 			const envVarsRegExp = /^(.+?)=(.*?$)/;
-			sourcedEnvironmentVars.toString().split('\n').forEach(row => {
-				// Environment variables cannot have = in their names, so we are safe with non-greedy regex.
-				// Do not trim at the end as variable values may have space(s) at the end.
-				let match = _.trimStart(row).match(envVarsRegExp);
 
-				if (match) {
-					environmentVariables[match[1].trim()] = match[2];
-				} else {
-					console.log(row + " does not match regex.");
-				}
-			});
+			sourcedEnvironmentVars
+				.toString()
+				.split('\n')
+				.forEach(row => {
+					// Environment variables cannot have = in their names, so we are safe with non-greedy regex.
+					// Do not trim at the end as variable values may have space(s) at the end.
+					let match = _.trimStart(row).match(envVarsRegExp);
 
-			return environmentVariables;
+					if (match) {
+						environmentVariables[match[1].trim()] = match[2];
+					} else {
+						console.log(row + " does not match regex.");
+					}
+				});
+
+			return addEtcPathToPath(environmentVariables);
 		}
 	} catch(err) {
 		console.error(err.message);
 	}
 
-	return process.env;
+	return addEtcPathToPath(process.env);
 };
 
 module.exports = {


### PR DESCRIPTION
The default terminal adds paths from /etc/path file to `$PATH` environment variable. Respect the `/etc/path` file in the returned object.