### PR TITLE
Source all known profiles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,24 @@ const fs = require("fs"),
 	_ = require("lodash"),
 	processWrapper = require("./process-wrapper");
 
+// Correct order for Login shells is described here:
+// http://hayne.net/MacDev/Notes/unixFAQ.html#shellStartup
+const profileOrder = [
+	".bash_profile",
+	".bash_login",
+	".profile",
+	".bashrc"
+];
+
+const envVarsRegExp = /^(.+?)=(.*?$)/;
+
+const getPathsToProfiles = (shell) => {
+	let currentProfileOrder = profileOrder.map(p => p.replace("bash", shell)) // in case the default shell is not bash
+		.map(p => path.join(process.env.HOME, p));
+
+	return currentProfileOrder.filter(profileName => fs.existsSync(profileName))
+};
+
 const addEtcPathToPath = (environmentVariables) => {
 	const pathToEtcPath = "/etc/paths";
 
@@ -27,6 +45,37 @@ const addEtcPathToPath = (environmentVariables) => {
 	return environmentVariables;
 };
 
+const getEnvironmentsFromProfile = (command) => {
+	try {
+		const sourcedEnvironmentVars = childProcess.execSync(command);
+
+		if (sourcedEnvironmentVars) {
+			let environmentVariables = {};
+
+			sourcedEnvironmentVars
+				.toString()
+				.split('\n')
+				.filter(row => !!row)
+				.forEach(row => {
+					// Environment variables cannot have = in their names, so we are safe with non-greedy regex.
+					// Do not trim at the end as variable values may have space(s) at the end.
+					let match = _.trimStart(row).match(envVarsRegExp);
+
+					if (match) {
+						environmentVariables[match[1].trim()] = match[2];
+					} else {
+						console.log(`During parsing result of ${command}, the line: '${row}' does not match regex for env vars: ${envVarsRegExp}.`);
+					}
+				});
+
+			return environmentVariables;
+		}
+	} catch (err) {
+		console.error(err.message);
+	}
+
+	return null;
+};
 /**
  * Gets all environment variables that the user has in the default terminal.
  * @returns {object} Dictionary with key-value pairs of all environment variables.
@@ -37,38 +86,22 @@ const getEnvironmentVariables = () => {
 	}
 
 	const shell = process.env && process.env.SHELL && path.basename(process.env.SHELL) || "bash",
-		pathToShell = process.env && process.env.SHELL || "/bin/bash";
+		pathToShell = process.env && process.env.SHELL || "/bin/bash",
+		pathsToProfiles = getPathsToProfiles(shell),
+		// Separate commands with `;` instead of && - this way even if `source` command fails for some reason, we'll still parse the result of `env` command.
+		commandsToExecute = _.map(pathsToProfiles, pathToProfileFile => `${pathToShell} -c "source ${pathToProfileFile}; env"`);
 
-	try {
-		const sourcedEnvironmentVars = childProcess.execSync(`${pathToShell} -ilc env`);
+	commandsToExecute.push(`${pathToShell} -ilc env`);
 
-		if (sourcedEnvironmentVars) {
-			let environmentVariables = {};
-
-			const envVarsRegExp = /^(.+?)=(.*?$)/;
-
-			sourcedEnvironmentVars
-				.toString()
-				.split('\n')
-				.forEach(row => {
-					// Environment variables cannot have = in their names, so we are safe with non-greedy regex.
-					// Do not trim at the end as variable values may have space(s) at the end.
-					let match = _.trimStart(row).match(envVarsRegExp);
-
-					if (match) {
-						environmentVariables[match[1].trim()] = match[2];
-					} else {
-						console.log(row + " does not match regex.");
-					}
-				});
-
-			return addEtcPathToPath(environmentVariables);
+	let environmentVariables = _.cloneDeep(process.env);
+	_.each(commandsToExecute, command => {
+		const currentEnv = getEnvironmentsFromProfile(command);
+		if (currentEnv) {
+			_.merge(environmentVariables, currentEnv);
 		}
-	} catch(err) {
-		console.error(err.message);
-	}
+	});
 
-	return addEtcPathToPath(process.env);
+	return addEtcPathToPath(environmentVariables);
 };
 
 module.exports = {

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,16 @@ describe("getEnvironmentVariables", () => {
 		childProcess.execSync = execSync;
 	});
 
+	const assertExpecteVarsInResult = (actualResult, expectedVariables) => {
+		_.each(expectedVariables, (varValue, varKey) => {
+			if (varKey === "PATH") {
+				assert.isTrue(actualResult[varKey].indexOf(varValue) !== -1);
+			} else {
+				assert.deepEqual(actualResult[varKey], varValue);
+			}
+		});
+	};
+
 	describe(`uses ${etcPaths}`, () => {
 		it("when there's PATH variable in it", () => {
 			let fs = require("fs");
@@ -51,8 +61,7 @@ describe("getEnvironmentVariables", () => {
 			const actualResult = index.getEnvironmentVariables();
 
 			expectedVariables.PATH = "path0:path1:path2:path3";
-
-			assert.deepEqual(actualResult, expectedVariables);
+			assertExpecteVarsInResult(actualResult, expectedVariables);
 		});
 	});
 
@@ -78,7 +87,7 @@ describe("getEnvironmentVariables", () => {
 		};
 
 		const actualResult = index.getEnvironmentVariables();
-		assert.deepEqual(actualResult, expectedVariables);
+		assertExpecteVarsInResult(actualResult, expectedVariables);
 	});
 
 	it("prints warning when environment variable does not match expected format", () => {
@@ -109,7 +118,7 @@ describe("getEnvironmentVariables", () => {
 
 		console.log = originalConsoleLog;
 
-		assert.deepEqual(loggedWarnings.length, 1);
+		assert.deepEqual(loggedWarnings.length, 5);
 
 		assert.isTrue(loggedWarnings[0].indexOf("does not match") !== -1);
 	});
@@ -180,7 +189,7 @@ describe("getEnvironmentVariables", () => {
 
 		assert.deepEqual(actualResult, process.env);
 
-		assert.deepEqual(loggedErrors.length, 1);
+		assert.deepEqual(loggedErrors.length, 5);
 
 		assert.deepEqual(loggedErrors[0], message);
 	});
@@ -209,8 +218,8 @@ describe("getEnvironmentVariables", () => {
 
 		process.env.SHELL = originalShellEnv;
 
-		assert.deepEqual(actualResult, expectedVariables);
-
+		// assert.deepEqual(actualResult, expectedVariables);
+		assertExpecteVarsInResult(actualResult, expectedVariables);
 		assert.isTrue(passedCommandArgument.indexOf(shellEnv) !== -1);
 	};
 


### PR DESCRIPTION
As the code `${shell} -ilc env` causes issues on some configurations, combine it with sourcing of all known profiles. This way we should cover all possible scenarios.

* Replace ` && ` with `;` when executing `${shell} -c "source ${profile} && env}"` - this way even if `source` command fails, we'll get the output of `env` command.
* Always respect `process.env` in the result.
* `-ilc` does not source `.profile` on some systems, so environments defined there have not been included in the result. Fix this by sourcing all files.