### PR TITLE
Add support for terminals with enabled iTerm integration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,16 +40,22 @@ const getEnvironmentVariables = () => {
 		pathToShell = process.env && process.env.SHELL || "/bin/bash";
 
 	try {
-		const sourcedEnvironmentVars = childProcess.execSync(`${pathToShell} -ilc env`);
+		let sourcedEnvironmentVars = childProcess.execSync(`${pathToShell} -ilc env`);
 
 		if (sourcedEnvironmentVars) {
+			// iTerm places some special symbols in the output, that break our parsing.
+			// They are enabled in case you use iTerm's shell integration: https://www.iterm2.com/documentation-shell-integration.html
+			// More information about the symbols: https://www.iterm2.com/documentation-escape-codes.html
+			// The escape sequence starts with ESC symbol (0x1b) and ends with BEL symbol (0x07)
+			// We do not need these symbols, so remove them and everything between them and parse the stdout after that.
+			sourcedEnvironmentVars = sourcedEnvironmentVars.toString().replace(/\u001b.*?\u0007/g, "");
+			const envVarsRegExp = /^(.+?)=(.*?$)/;
 			let environmentVariables = {};
 
-			const envVarsRegExp = /^(.+?)=(.*?$)/;
-
 			sourcedEnvironmentVars
-				.toString()
 				.split('\n')
+				.map(row => _.trimStart(row))
+				.filter(row => !!row)
 				.forEach(row => {
 					// Environment variables cannot have = in their names, so we are safe with non-greedy regex.
 					// Do not trim at the end as variable values may have space(s) at the end.
@@ -64,7 +70,7 @@ const getEnvironmentVariables = () => {
 
 			return addEtcPathToPath(environmentVariables);
 		}
-	} catch(err) {
+	} catch (err) {
 		console.error(err.message);
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shell-vars",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Code that sources correct profiles, so that you can use all Environment variables declared in them.",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
When iTerm integration is enabled, some specific symbols are printed to the output. This breaks the parsing of result of `bash -ilc env` command and we loose some environment variables.
Remove the symbols from iTerm and everything between them.