### PR TITLE
Get variables from Node.js directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@ const fs = require("fs"),
 	childProcess = require("child_process"),
 	path = require("path"),
 	_ = require("lodash"),
-	processWrapper = require("./process-wrapper");
+	processWrapper = require("./process-wrapper"),
+	temp = require("temp");
 
 const addEtcPathToPath = (environmentVariables) => {
 	const pathToEtcPath = "/etc/paths";
@@ -27,18 +28,20 @@ const addEtcPathToPath = (environmentVariables) => {
 	return environmentVariables;
 };
 
-/**
- * Gets all environment variables that the user has in the default terminal.
- * @returns {object} Dictionary with key-value pairs of all environment variables.
- */
-const getEnvironmentVariables = () => {
-	if (processWrapper.getProcessPlatform() === "win32") {
-		return process.env;
+const getEnvironmentVariablesFromNodeProcess = (pathToShell) => {
+	try {
+		temp.track();
+		const pathToTempFile = temp.path("get-shell-vars-process-env");
+		const bashCommandSpawningNode = `${pathToShell} -ilc "node -e 'require(\\"fs\\").writeFileSync(\\"${pathToTempFile}\\", JSON.stringify(process.env))'"`;
+		childProcess.execSync(bashCommandSpawningNode);
+		const env = JSON.parse(fs.readFileSync(pathToTempFile));
+		return env;
+	} catch (err) {
+		console.log("Unable to get environment variables from node, will try another approach.");
 	}
+};
 
-	const shell = process.env && process.env.SHELL && path.basename(process.env.SHELL) || "bash",
-		pathToShell = process.env && process.env.SHELL || "/bin/bash";
-
+const getEnvironmentVariablesFromEnvCommand = (pathToShell) => {
 	try {
 		let sourcedEnvironmentVars = childProcess.execSync(`${pathToShell} -ilc env`);
 
@@ -68,13 +71,27 @@ const getEnvironmentVariables = () => {
 					}
 				});
 
-			return addEtcPathToPath(environmentVariables);
+			return environmentVariables;
 		}
 	} catch (err) {
 		console.error(err.message);
 	}
+}
 
-	return addEtcPathToPath(process.env);
+/**
+ * Gets all environment variables that the user has in the default terminal.
+ * @returns {object} Dictionary with key-value pairs of all environment variables.
+ */
+const getEnvironmentVariables = () => {
+	if (processWrapper.getProcessPlatform() === "win32") {
+		return process.env;
+	}
+
+	const shell = process.env && process.env.SHELL && path.basename(process.env.SHELL) || "bash",
+		pathToShell = process.env && process.env.SHELL || "/bin/bash";
+
+	const environmentVariables = getEnvironmentVariablesFromNodeProcess(pathToShell) || getEnvironmentVariablesFromEnvCommand(pathToShell) || process.env;
+	return addEtcPathToPath(environmentVariables);
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "spec-xunit-file": "0.0.1-3"
   },
   "dependencies": {
-    "lodash": "4.16.4"
+    "lodash": "4.16.4",
+    "temp": "0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shell-vars",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Code that sources correct profiles, so that you can use all Environment variables declared in them.",
   "main": "./lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,17 @@ describe("getEnvironmentVariables", () => {
 	const readFileSync = fs.readFileSync;
 	const existsSync = fs.existsSync;
 	const execSync = childProcess.execSync;
+	const consoleLog = console.log;
+	const consoleError = console.error;
+	const shellEnvVar = process.env.SHELL;
+
+	const defaultExpectedVariables = {
+		"VAR1": "1",
+		"VAR2": "2",
+		"VAR4": "1=2=3=4",
+		"VAR5": "   1 2   3 ",
+		"VAR6": "1 2 3"
+	};
 
 	beforeEach(() => {
 		processWrapper.getProcessPlatform = () => "tests";
@@ -24,6 +35,9 @@ describe("getEnvironmentVariables", () => {
 		fs.readFileSync = readFileSync;
 		fs.existsSync = existsSync;
 		childProcess.execSync = execSync;
+		console.log = consoleLog;
+		console.error = consoleError;
+		process.env.SHELL = shellEnvVar;
 	});
 
 	describe(`uses ${etcPaths}`, () => {
@@ -31,14 +45,7 @@ describe("getEnvironmentVariables", () => {
 			fs.existsSync = (filePath) => filePath === etcPaths;
 			fs.readFileSync = (filePath, encoding) => 'path1\npath2\npath3';
 
-			const expectedVariables = {
-				"VAR1": "1",
-				"VAR2": "2",
-				"VAR4": "1=2=3=4",
-				"VAR5": "   1 2   3 ",
-				"VAR6": "1 2 3",
-				"PATH": "path0"
-			};
+			const expectedVariables = _.merge({}, defaultExpectedVariables, { PATH: "path0" });
 
 			childProcess.execSync = (command) => {
 				return _.map(expectedVariables, (value, key) => {
@@ -54,192 +61,208 @@ describe("getEnvironmentVariables", () => {
 		});
 	});
 
-	it("returns correct variables", () => {
-		fs.existsSync = (filePath) => {
-			return filePath !== etcPaths;
-		};
+	describe("when Node.js is used", () => {
+		it("prints warning that cannot get environment variables via node when spawn of child process with node arg fails", () => {
+			fs.existsSync = (filePath) => filePath !== etcPaths;
 
-		const expectedVariables = {
-			"VAR1": "1",
-			"VAR2": "2",
-			"VAR4": "1=2=3=4",
-			"VAR5": "   1 2   3 ",
-			"VAR6": "1 2 3"
-		};
+			const execSyncCommands = [];
+			childProcess.execSync = (command) => {
+				execSyncCommands.push(command);
+				if (command.indexOf("node") !== -1) {
+					throw new Error("Unable to find node");
+				}
 
-		let childProcess = require("child_process");
-		childProcess.execSync = (command) => {
-			return _.map(expectedVariables, (value, key) => {
-				return `${key}=${value}`;
-			}).join('\n');
-		};
-
-		const actualResult = index.getEnvironmentVariables();
-		assert.deepEqual(actualResult, expectedVariables);
-	});
-
-	it("prints warning when environment variable does not match expected format", () => {
-		fs.existsSync = (filePath) => {
-			return filePath !== etcPaths;
-		};
-
-		const expectedVariables = {
-			"": "1"
-		};
-
-		childProcess.execSync = (command) => {
-			return _.map(expectedVariables, (value, key) => {
-				return `${key}=${value}`;
-			}).join('\n');
-		};
-
-		let loggedWarnings = [];
-
-		const originalConsoleLog = console.log;
-		console.log = (data) => {
-			loggedWarnings.push(data);
-		};
-
-		const actualResult = index.getEnvironmentVariables();
-
-		console.log = originalConsoleLog;
-
-		assert.deepEqual(loggedWarnings.length, 1);
-
-		assert.isTrue(loggedWarnings[0].indexOf("does not match") !== -1);
-	});
-
-	it("returns process.env on windows", () => {
-		fs.existsSync = (filePath) => true;
-
-		const expectedVariables = {
-			"VAR1": "1"
-		};
-
-		childProcess.execSync = (command) => {
-			return _.map(expectedVariables, (value, key) => {
-				return `${key}=${value}`;
-			}).join('\n');
-		};
-
-		processWrapper.getProcessPlatform = () => "win32";
-
-		const actualResult = index.getEnvironmentVariables();
-		assert.deepEqual(actualResult, process.env);
-	});
-
-	const emptyTestData = [
-		null,
-		undefined,
-		''
-	];
-
-	_.each(emptyTestData, value => {
-		it(`returns process.env when child process does not return any data (${value})`, () => {
-			fs.existsSync = (filePath) => {
-				return filePath !== etcPaths;
+				return _.map(defaultExpectedVariables, (value, key) => `${key}=${value}`).join('\n');
 			};
 
-			childProcess.execSync = (command) => value;
+			let loggedWarnings = [];
+
+			console.log = (data) => {
+				loggedWarnings.push(data);
+			};
+
+			const actualResult = index.getEnvironmentVariables();
+
+			assert.deepEqual(loggedWarnings.length, 1);
+			assert.isTrue(loggedWarnings[0].indexOf("node") !== -1);
+			assert.deepEqual(actualResult, defaultExpectedVariables);
+		});
+
+		it("gets the process env written in a file by executed node process", () => {
+			fs.existsSync = (filePath) => filePath !== etcPaths;
+
+			const execSyncCommands = [];
+			childProcess.execSync = (command) => {
+				execSyncCommands.push(command);
+				if (command.indexOf("node") !== -1) {
+					return "";
+				}
+
+				throw new Error("You shouldn't get here!");
+			};
+
+			fs.readFileSync = (filePath, encoding) => JSON.stringify(defaultExpectedVariables);
+
+			const actualResult = index.getEnvironmentVariables();
+			assert.deepEqual(actualResult, defaultExpectedVariables);
+		});
+	});
+
+	describe("when env is used", () => {
+		it("returns correct variables", () => {
+			fs.existsSync = (filePath) => filePath !== etcPaths;
+
+			childProcess.execSync = (command) => {
+				return _.map(defaultExpectedVariables, (value, key) => `${key}=${value}`).join('\n');
+			};
+
+			const actualResult = index.getEnvironmentVariables();
+			assert.deepEqual(actualResult, defaultExpectedVariables);
+		});
+
+		it("prints warning when environment variable does not match expected format", () => {
+			fs.existsSync = (filePath) => filePath !== etcPaths;
+
+			const expectedVariables = {
+				"": "1"
+			};
+
+			childProcess.execSync = (command) => {
+				return _.map(expectedVariables, (value, key) => `${key}=${value}`).join('\n');
+			};
+
+			let loggedWarnings = [];
+
+			console.log = (data) => {
+				loggedWarnings.push(data);
+			};
+
+			const actualResult = index.getEnvironmentVariables();
+
+			assert.deepEqual(loggedWarnings.length, 2);
+			assert.isTrue(loggedWarnings[0].indexOf("Unable to get environment variables from node") !== -1);
+
+			assert.isTrue(loggedWarnings[1].indexOf("does not match") !== -1);
+		});
+
+		it("returns process.env on windows", () => {
+			fs.existsSync = (filePath) => true;
+
+			const expectedVariables = {
+				"VAR1": "1"
+			};
+
+			childProcess.execSync = (command) => {
+				return _.map(expectedVariables, (value, key) => `${key}=${value}`).join('\n');
+			};
+
+			processWrapper.getProcessPlatform = () => "win32";
 
 			const actualResult = index.getEnvironmentVariables();
 			assert.deepEqual(actualResult, process.env);
 		});
-	});
 
-	it(`returns process.env when child process throws`, () => {
-		fs.existsSync = (filePath) => {
-			return filePath !== etcPaths;
+		const emptyTestData = [
+			null,
+			undefined,
+			''
+		];
+
+		_.each(emptyTestData, value => {
+			it(`returns process.env when child process does not return any data (${value})`, () => {
+				fs.existsSync = (filePath) => filePath !== etcPaths;
+
+				childProcess.execSync = (command) => value;
+
+				const actualResult = index.getEnvironmentVariables();
+				assert.deepEqual(actualResult, process.env);
+			});
+		});
+
+		it(`returns process.env when child process throws`, () => {
+			fs.existsSync = (filePath) => filePath !== etcPaths;
+
+			const message = "execSyncThrows";
+			childProcess.execSync = (command) => {
+				throw new Error(message);
+			};
+
+			let loggedErrors = [];
+			console.error = (data) => {
+				loggedErrors.push(data);
+			};
+
+			const actualResult = index.getEnvironmentVariables();
+
+			assert.deepEqual(actualResult, process.env);
+
+			assert.deepEqual(loggedErrors.length, 1);
+
+			assert.deepEqual(loggedErrors[0], message);
+		});
+
+		const verifySourceCommand = (shellEnv) => {
+			process.env.SHELL = shellEnv;
+
+			fs.existsSync = (filePath) => false;
+
+			const expectedVariables = {
+				"VAR1": "1"
+			};
+
+			let passedCommandArgument;
+
+			childProcess.execSync = (command) => {
+				passedCommandArgument = command;
+
+				return _.map(expectedVariables, (value, key) => `${key}=${value}`).join('\n');
+			};
+
+			const actualResult = index.getEnvironmentVariables();
+
+			assert.deepEqual(actualResult, expectedVariables);
+
+			assert.isTrue(passedCommandArgument.indexOf(shellEnv) !== -1);
 		};
 
-		const message = "execSyncThrows";
-		childProcess.execSync = (command) => {
-			throw new Error(message);
-		};
-
-		const originalConsoleErr = console.error;
-		let loggedErrors = [];
-		console.error = (data) => {
-			loggedErrors.push(data);
-		};
-
-		const actualResult = index.getEnvironmentVariables();
-
-		console.error = originalConsoleErr;
-
-		assert.deepEqual(actualResult, process.env);
-
-		assert.deepEqual(loggedErrors.length, 1);
-
-		assert.deepEqual(loggedErrors[0], message);
-	});
-
-	const verifySourceCommand = (shellEnv) => {
-		const originalShellEnv = process.env.SHELL;
-		process.env.SHELL = shellEnv;
-
-		fs.existsSync = (filePath) => false;
-
-		const expectedVariables = {
-			"VAR1": "1"
-		};
-
-		let passedCommandArgument;
-
-		childProcess.execSync = (command) => {
-			passedCommandArgument = command;
-
-			return _.map(expectedVariables, (value, key) => {
-				return `${key}=${value}`;
-			}).join('\n');
-		};
-
-		const actualResult = index.getEnvironmentVariables();
-
-		process.env.SHELL = originalShellEnv;
-
-		assert.deepEqual(actualResult, expectedVariables);
-
-		assert.isTrue(passedCommandArgument.indexOf(shellEnv) !== -1);
-	};
-
-	it("works when iTerm shell integration is enabled", () => {
-		const str = Buffer.from(`Now using node v7.6.0 (npm v5.0.0)
+		it("works when iTerm shell integration is enabled", () => {
+			const str = Buffer.from(`Now using node v7.6.0 (npm v5.0.0)
 \u001b]1337;RemoteHost=username@machinename\u0007\u001b]1337;CurrentDir=/Users/username/Work/get-shell-vars\u0007\u001b]1337;ShellIntegrationVersion=5;shell=bash\u0007MANPATH=/Users/username/.nvm/versions/node/v7.6.0/share/man:/usr/share/man:/usr/local/share/man:/Applications/Xcode.app/Contents/Developer/usr/share/man:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man
 TERM_PROGRAM=Apple_Terminal`);
-		const originalShellEnv = process.env.SHELL;
-		process.env.SHELL = ".bash_profile";
-		fs.existsSync = (filePath) => filePath === etcPaths;
-		fs.readFileSync = (filePath, encoding) => 'path1\npath2\npath3';
 
-		const expectedVariables = {
-			"MANPATH": "/Users/username/.nvm/versions/node/v7.6.0/share/man:/usr/share/man:/usr/local/share/man:/Applications/Xcode.app/Contents/Developer/usr/share/man:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man",
-			"TERM_PROGRAM": "Apple_Terminal",
-			"PATH": "path1:path2:path3"
-		};
+			process.env.SHELL = ".bash_profile";
+			fs.existsSync = (filePath) => filePath === etcPaths;
+			fs.readFileSync = (filePath, encoding) => 'path1\npath2\npath3';
 
-		let passedCommandArgument;
+			const expectedVariables = {
+				"MANPATH": "/Users/username/.nvm/versions/node/v7.6.0/share/man:/usr/share/man:/usr/local/share/man:/Applications/Xcode.app/Contents/Developer/usr/share/man:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man",
+				"TERM_PROGRAM": "Apple_Terminal",
+				"PATH": "path1:path2:path3"
+			};
 
-		childProcess.execSync = (command) => {
-			passedCommandArgument = command;
+			let passedCommandArgument;
 
-			return str;
-		};
+			childProcess.execSync = (command) => {
+				passedCommandArgument = command;
 
-		const actualResult = index.getEnvironmentVariables();
-		process.env.SHELL = originalShellEnv;
-		assert.deepEqual(actualResult, expectedVariables);
+				return str;
+			};
+
+			const actualResult = index.getEnvironmentVariables();
+			assert.deepEqual(actualResult, expectedVariables);
+		});
+
+		it("when default shell is not set, uses bash", () => {
+			verifySourceCommand(".bash_profile", '');
+		});
+
+		it("uses custom shell, when bash is not default", () => {
+			verifySourceCommand(".zshrc", "/bin/zsh");
+		});
+
+		it("uses custom shell, when bash is not default and default shell is not full path", () => {
+			verifySourceCommand(".zshrc", "zsh");
+		});
 	});
 
-	it("when default shell is not set, uses bash", () => {
-		verifySourceCommand(".bash_profile", '');
-	});
-
-	it("uses custom shell, when bash is not default", () => {
-		verifySourceCommand(".zshrc", "/bin/zsh");
-	});
-
-	it("uses custom shell, when bash is not default and default shell is not full path", () => {
-		verifySourceCommand(".zshrc", "zsh");
-	});
 });


### PR DESCRIPTION
Parsing stdout of a process could fail due to many reasons. But executing Node.js in a child process, that already has all required variables, will allow us to get the `process.env` object. It already has parsed the variables and we just have to read them.
So introduce this as a first option, in case there's Node.js on user's machine.