### PR TITLE
Support custom user configs for shell and terminal

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,9 +18,6 @@ bin/*.cmd
 
 config/config-*
 
-lib/**/*.ts
-lib/**/*.js.map
-
 scratch/
 test/
 **/docs/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
+- '6'
 git:
   submodules: false
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # get-shell-vars
 Code that sources correct profiles, so that you can use all Environment variables declared in them.
 
-### Usage
+## Usage
+### Using the default settings for current OS
+In case you want to use the default settings for current OS, just call `getEnvironmentVariables` method without arguments.
+
 1. First install the package:
 ```
 npm install --save get-shell-vars
@@ -9,12 +12,73 @@ npm install --save get-shell-vars
 
 2. Now use it in your code:
 ```
-let shellVars = require("get-shell-vars");
+const shellVars = require("get-shell-vars");
 shellVars.getEnvironmentVariables();
 ```
 
 The result is an object with all environment variables.
 
-### System requirements
+### Using custom shell and terminal settings
+In many cases, you may need to use specific SHELL or custom terminal settings, you may pass an object to `getEnvironmentVariables` method and the module will respect them instead of the default ones.
+The object has the following definition:
+```TypeScript
+/**
+ * Defines the user specific configuration of the shell and terminal.
+ */
+interface IUserConfiguration {
+    /**
+     * Path to the shell that should be used.
+     * @example "/bin/sh"
+     * By default this value is taken from SHELL environment variable and in case it is not set, "/bin/bash" is used.
+     */
+    shell: string;
 
-The package requires Node.js 4.0.0 or later as it uses let, const, lambdas, etc.
+    /**
+     * Describes the configuration of the terminal that the user would like to have.
+     * These settings modify the behavior, i.e. which profile files of the respective shell will be loaded.
+     */
+    terminalConfiguration: {
+        /**
+         * Defines if the terminal is interactive or no.
+         * `true` by default.
+         */
+        isInteractive: boolean;
+
+        /**
+         * Defines if login session will be started.
+         * `false` by default on Linux.
+         * `true` on all other OSes.
+         */
+        isLogin: boolean;
+    }
+}
+```
+
+You can pass only the properties that you want to modify. For example:
+```JavaScript
+const shellVars = require("get-shell-vars");
+const userConfiguration = {
+    terminalConfiguration: {
+        isLogin: true
+    }
+};
+
+shellVars.getEnvironmentVariables(userConfiguration);
+```
+
+## OS specific information
+The module will use different shell settings on each OS.
+
+### Windows
+The module will always return the value of `process.env`.
+
+### Linux
+The module will spawn a new interactive, **non-login** shell. The shell is taken from `SHELL` environment variable.
+
+### macOS
+The module will spawn a new interactive, **login** shell. The shell is taken from `SHELL` environment variable.
+
+
+## System requirements
+
+The package requires Node.js 6.0.0 or later.

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,12 +28,13 @@ const addEtcPathToPath = (environmentVariables) => {
 	return environmentVariables;
 };
 
-const getEnvironmentVariablesFromNodeProcess = (pathToShell) => {
+const getEnvironmentVariablesFromNodeProcess = (shellStringForExecution) => {
 	try {
 		temp.track();
 		const pathToTempFile = temp.path("get-shell-vars-process-env");
-		const bashCommandSpawningNode = `${pathToShell} -ilc "node -e 'require(\\"fs\\").writeFileSync(\\"${pathToTempFile}\\", JSON.stringify(process.env))'"`;
-		childProcess.execSync(bashCommandSpawningNode);
+
+		const shellCommandSpawningNode = `${shellStringForExecution} "node -e 'require(\\"fs\\").writeFileSync(\\"${pathToTempFile}\\", JSON.stringify(process.env))'"`;
+		childProcess.execSync(shellCommandSpawningNode);
 		const env = JSON.parse(fs.readFileSync(pathToTempFile));
 		return env;
 	} catch (err) {
@@ -41,9 +42,9 @@ const getEnvironmentVariablesFromNodeProcess = (pathToShell) => {
 	}
 };
 
-const getEnvironmentVariablesFromEnvCommand = (pathToShell) => {
+const getEnvironmentVariablesFromEnvCommand = (shellStringForExecution) => {
 	try {
-		let sourcedEnvironmentVars = childProcess.execSync(`${pathToShell} -ilc env`);
+		let sourcedEnvironmentVars = childProcess.execSync(`${shellStringForExecution} env`);
 
 		if (sourcedEnvironmentVars) {
 			// iTerm places some special symbols in the output, that break our parsing.
@@ -76,21 +77,49 @@ const getEnvironmentVariablesFromEnvCommand = (pathToShell) => {
 	} catch (err) {
 		console.error(err.message);
 	}
-}
+};
+
+const getDefaultConfigurationForOS = (platform) => {
+	const shell = process.env && process.env.SHELL || "/bin/bash";
+	const isInteractive = true;
+	const isLogin = platform !== "linux";
+
+	return {
+		shell,
+		terminalConfiguration: {
+			isInteractive,
+			isLogin
+		}
+	};
+};
+
+const getShellStringForExecution = (shellConfig) => {
+	const pathToShell = shellConfig.shell;
+	const interactiveFlag = shellConfig.terminalConfiguration.isInteractive ? "i" : "";
+	const loginFlag = shellConfig.terminalConfiguration.isLogin ? "l" : "";
+
+	const shellStringForExecution = `"${pathToShell}" -${interactiveFlag}${loginFlag}c`;
+	return shellStringForExecution;
+};
 
 /**
  * Gets all environment variables that the user has in the default terminal.
+ * @param {object} userConfiguration Specific config for the shell and terminal used.
  * @returns {object} Dictionary with key-value pairs of all environment variables.
  */
-const getEnvironmentVariables = () => {
-	if (processWrapper.getProcessPlatform() === "win32") {
+const getEnvironmentVariables = (userConfiguration) => {
+	const platform = processWrapper.getProcessPlatform();
+
+	if (platform === "win32") {
 		return process.env;
 	}
 
-	const shell = process.env && process.env.SHELL && path.basename(process.env.SHELL) || "bash",
-		pathToShell = process.env && process.env.SHELL || "/bin/bash";
+	const defaultConfiguration = getDefaultConfigurationForOS(platform);
 
-	const environmentVariables = getEnvironmentVariablesFromNodeProcess(pathToShell) || getEnvironmentVariablesFromEnvCommand(pathToShell) || process.env;
+	const shellConfig = _.merge({}, defaultConfiguration, userConfiguration);
+	const shellStringForExecution = getShellStringForExecution(shellConfig);
+
+	const environmentVariables = getEnvironmentVariablesFromNodeProcess(shellStringForExecution) || getEnvironmentVariablesFromEnvCommand(shellStringForExecution) || process.env;
 	return addEtcPathToPath(environmentVariables);
 };
 

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -1,0 +1,43 @@
+/**
+ * Defines the user specific configuration of the shell and terminal.
+ */
+interface IUserConfiguration {
+    /**
+     * Path to the shell that should be used.
+     * @example "/bin/sh"
+     * By default this value is taken from SHELL environment variable and in case it is not set, "/bin/bash" is used.
+     */
+    shell?: string;
+
+    /**
+     * Describes the configuration of the terminal that the user would like to have.
+     * These settings modify the behavior, i.e. which profile files of the respective shell will be loaded.
+     */
+    terminalConfiguration?: {
+        /**
+         * Defines if the terminal is interactive or no.
+         * `true` by default.
+         */
+        isInteractive?: boolean;
+
+        /**
+         * Defines if login session will be started.
+         * `false` by default on Linux.
+         * `true` on all other OSes.
+         */
+        isLogin?: boolean;
+    }
+}
+
+interface IStringDicitionary {
+    [key: string]: string;
+}
+
+declare module "get-shell-vars" {
+    /**
+     * Gets a JSON object with all environment variables.
+     * @param {IUserConfiguration} userConfiguration Optional argument that can be used to modify the settings of the shell session that will be started to get environment variables.
+     * @returns {IStringDicitionary} JSON object with key-value pairs that are all environment variables.
+     */
+    function getEnvironmentVariables(userConfiguration?: IUserConfiguration): IStringDicitionary;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shell-vars",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Code that sources correct profiles, so that you can use all Environment variables declared in them.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "istanbul cover node_modules/mocha/bin/_mocha -- --recursive --reporter spec-xunit-file --timeout 150000 test/"
   },
+  "types": "./lib/typings.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rosen-vladimirov/get-shell-vars.git"


### PR DESCRIPTION
In many cases users may have different terminals/shells, so the default settings may not work on their side.
So make it possible to specify the default shell and the type of terminal - is it login and is it interactive.
Pass object to `getEnvironmentVariables` that has the following type:
```TypeScript
{
    shell: string;
    terminalConfiguration: {
        isInteractive: boolean;
        isLogin: boolean;
    }
}
```

The default values are:
- shell will be set to `process.env.SHELL` or `/bin/bash`.
- `isInteractive` will be `true`
- `isLogin` will be false for Linux and true for all other OSes.

NOTE: This is breaking change for Linux users - until now we've spawned login shell.

Update README and add typings for the package